### PR TITLE
feat: add equatable

### DIFF
--- a/bin/distributions/paper/paper_api.dart
+++ b/bin/distributions/paper/paper_api.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -27,7 +28,7 @@ abstract class PaperApi {
 }
 
 @JsonSerializable()
-class PaperVersion {
+class PaperVersion extends Equatable {
   @JsonKey(name: 'project_id')
   final String projectId;
   @JsonKey(name: 'project_name')
@@ -44,30 +45,14 @@ class PaperVersion {
   Map<String, dynamic> toJson() => _$PaperVersionToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is PaperVersion &&
-          runtimeType == other.runtimeType &&
-          projectId == other.projectId &&
-          projectName == other.projectName &&
-          version == other.version &&
-          builds == other.builds;
+  List<Object?> get props => [projectId, projectName, version, builds];
 
   @override
-  int get hashCode =>
-      projectId.hashCode ^
-      projectName.hashCode ^
-      version.hashCode ^
-      builds.hashCode;
-
-  @override
-  String toString() {
-    return 'PaperVersion{projectId: $projectId, projectName: $projectName, version: $version, builds: $builds}';
-  }
+  bool? get stringify => true;
 }
 
 @JsonSerializable()
-class PaperProject {
+class PaperProject extends Equatable {
   @JsonKey(name: 'project_id')
   final String projectId;
   @JsonKey(name: 'project_name')
@@ -85,30 +70,14 @@ class PaperProject {
   Map<String, dynamic> toJson() => _$PaperProjectToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is PaperProject &&
-          runtimeType == other.runtimeType &&
-          projectId == other.projectId &&
-          projectName == other.projectName &&
-          versionGroups == other.versionGroups &&
-          versions == other.versions;
+  List<Object?> get props => [projectId, projectName, versionGroups, versions];
 
   @override
-  int get hashCode =>
-      projectId.hashCode ^
-      projectName.hashCode ^
-      versionGroups.hashCode ^
-      versions.hashCode;
-
-  @override
-  String toString() {
-    return 'PaperProject{projectId: $projectId, projectName: $projectName, versionGroups: $versionGroups, versions: $versions}';
-  }
+  bool? get stringify => true;
 }
 
 @JsonSerializable()
-class PaperBuild {
+class PaperBuild extends Equatable {
   @JsonKey(name: 'project_id')
   final String projectId;
   @JsonKey(name: 'project_name')
@@ -125,30 +94,14 @@ class PaperBuild {
   Map<String, dynamic> toJson() => _$PaperBuildToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is PaperBuild &&
-          runtimeType == other.runtimeType &&
-          projectId == other.projectId &&
-          projectName == other.projectName &&
-          build == other.build &&
-          downloads == other.downloads;
+  List<Object?> get props => [projectId, projectName, build, downloads];
 
   @override
-  int get hashCode =>
-      projectId.hashCode ^
-      projectName.hashCode ^
-      build.hashCode ^
-      downloads.hashCode;
-
-  @override
-  String toString() {
-    return 'PaperBuild{projectId: $projectId, projectName: $projectName, build: $build, downloads: $downloads}';
-  }
+  bool? get stringify => true;
 }
 
 @JsonSerializable()
-class PaperDownloads {
+class PaperDownloads extends Equatable{
   final PaperDownload application;
 
   const PaperDownloads(this.application);
@@ -159,23 +112,11 @@ class PaperDownloads {
   Map<String, dynamic> toJson() => _$PaperDownloadsToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is PaperDownloads &&
-          runtimeType == other.runtimeType &&
-          application == other.application;
-
-  @override
-  int get hashCode => application.hashCode;
-
-  @override
-  String toString() {
-    return 'PaperDownloads{application: $application}';
-  }
+  List<Object?> get props => [application];
 }
 
 @JsonSerializable()
-class PaperDownload {
+class PaperDownload extends Equatable {
   final String name;
   final String sha256;
 
@@ -187,24 +128,14 @@ class PaperDownload {
   Map<String, dynamic> toJson() => _$PaperDownloadToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is PaperDownload &&
-          runtimeType == other.runtimeType &&
-          name == other.name &&
-          sha256 == other.sha256;
+  List<Object?> get props => [name, sha256];
 
   @override
-  int get hashCode => name.hashCode ^ sha256.hashCode;
-
-  @override
-  String toString() {
-    return 'PaperDownloads{name: $name, sha256: $sha256}';
-  }
+  bool? get stringify => true;
 }
 
 @JsonSerializable()
-class PaperVersionGroup {
+class PaperVersionGroup extends Equatable {
   @JsonKey(name: 'version_group')
   final String versionGroup;
 
@@ -221,18 +152,8 @@ class PaperVersionGroup {
   VersionGroup toVersionGroup() => VersionGroup(versionGroup, versions);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is PaperVersionGroup &&
-          runtimeType == other.runtimeType &&
-          versionGroup == other.versionGroup &&
-          versions == other.versions;
+  List<Object?> get props => [versionGroup, versions];
 
   @override
-  int get hashCode => versionGroup.hashCode ^ versions.hashCode;
-
-  @override
-  String toString() {
-    return 'PaperVersionGroup{versionGroup: $versionGroup, versions: $versions}';
-  }
+  bool? get stringify => true;
 }

--- a/bin/jdk/installer/adoptium/adoptium_api.dart
+++ b/bin/jdk/installer/adoptium/adoptium_api.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:retrofit/http.dart';
 
@@ -21,7 +22,7 @@ abstract class AdoptiumApi {
 }
 
 @JsonSerializable()
-class AdoptiumReleases {
+class AdoptiumReleases extends Equatable {
   @JsonKey(name: 'available_lts_releases')
   final List<int> availableLtsReleases;
   @JsonKey(name: 'available_releases')
@@ -41,30 +42,14 @@ class AdoptiumReleases {
   Map<String, dynamic> toJson() => _$AdoptiumReleasesToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AdoptiumReleases &&
-          runtimeType == other.runtimeType &&
-          availableLtsReleases == other.availableLtsReleases &&
-          availableReleases == other.availableReleases &&
-          mostResentFeatureRelease == other.mostResentFeatureRelease &&
-          mostResentLtsRelease == other.mostResentLtsRelease;
+  List<Object?> get props => [availableLtsReleases, availableReleases, mostResentFeatureRelease, mostResentLtsRelease];
 
   @override
-  int get hashCode =>
-      availableLtsReleases.hashCode ^
-      availableReleases.hashCode ^
-      mostResentFeatureRelease.hashCode ^
-      mostResentLtsRelease.hashCode;
-
-  @override
-  String toString() {
-    return 'AdoptiumReleases{availableLtsReleases: $availableLtsReleases, availableReleases: $availableReleases, mostResentFeatureRelease: $mostResentFeatureRelease, mostResentLtsRelease: $mostResentLtsRelease}';
-  }
+  bool? get stringify => true;
 }
 
 @JsonSerializable()
-class AdoptiumFeatureRelease {
+class AdoptiumFeatureRelease extends Equatable {
   final List<AdoptiumBinary> binaries;
 
   const AdoptiumFeatureRelease(this.binaries);
@@ -75,23 +60,14 @@ class AdoptiumFeatureRelease {
   Map<String, dynamic> toJson() => _$AdoptiumFeatureReleaseToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AdoptiumFeatureRelease &&
-          runtimeType == other.runtimeType &&
-          binaries == other.binaries;
+  List<Object?> get props => [binaries];
 
   @override
-  int get hashCode => binaries.hashCode;
-
-  @override
-  String toString() {
-    return 'AdoptiumFeatureRelease{binaries: $binaries}';
-  }
+  bool? get stringify => true;
 }
 
 @JsonSerializable()
-class AdoptiumBinary {
+class AdoptiumBinary extends Equatable {
   final String architecture;
   @JsonKey(name: 'image_type')
   final String imageType;
@@ -109,32 +85,14 @@ class AdoptiumBinary {
   Map<String, dynamic> toJson() => _$AdoptiumBinaryToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AdoptiumBinary &&
-          runtimeType == other.runtimeType &&
-          architecture == other.architecture &&
-          imageType == other.imageType &&
-          jvmImpl == other.jvmImpl &&
-          os == other.os &&
-          package == other.package;
+  List<Object?> get props => [architecture, imageType, jvmImpl, os, package];
 
   @override
-  int get hashCode =>
-      architecture.hashCode ^
-      imageType.hashCode ^
-      jvmImpl.hashCode ^
-      os.hashCode ^
-      package.hashCode;
-
-  @override
-  String toString() {
-    return 'AdoptiumBinary{architecture: $architecture, imageType: $imageType, jvmImpl: $jvmImpl, os: $os, package: $package}';
-  }
+  bool? get stringify => true;
 }
 
 @JsonSerializable()
-class AdoptiumPackage {
+class AdoptiumPackage extends Equatable {
   final String checksum;
   final String link;
   final String name;
@@ -147,18 +105,8 @@ class AdoptiumPackage {
   Map<String, dynamic> toJson() => _$AdoptiumPackageToJson(this);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AdoptiumPackage &&
-          runtimeType == other.runtimeType &&
-          checksum == other.checksum &&
-          link == other.link;
+  List<Object?> get props => [checksum, link, name];
 
   @override
-  int get hashCode => checksum.hashCode ^ link.hashCode;
-
-  @override
-  String toString() {
-    return 'AdoptiumPackage{checksum: $checksum, link: $link}';
-  }
+  bool? get stringify => true;
 }

--- a/bin/jdk/jre_installation.dart
+++ b/bin/jdk/jre_installation.dart
@@ -1,4 +1,6 @@
-class JreInstallation {
+import 'package:equatable/equatable.dart';
+
+class JreInstallation extends Equatable {
   final JreVersion version;
   final String path;
 
@@ -7,43 +9,17 @@ class JreInstallation {
   JreInstallation(this.version, this.path);
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is JreInstallation &&
-          runtimeType == other.runtimeType &&
-          version == other.version &&
-          path == other.path;
+  List<Object?> get props => [version, path];
 
   @override
-  int get hashCode => version.hashCode ^ path.hashCode;
-
-  @override
-  String toString() {
-    return 'JreInstallation{version: $version, path: $path}';
-  }
+  bool? get stringify => true;
 }
 
-class JreVersion extends Comparable<JreVersion> {
+class JreVersion extends Comparable<JreVersion> with EquatableMixin {
   final int languageVersion;
   final int update;
 
   JreVersion(this.languageVersion, this.update);
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is JreVersion &&
-          runtimeType == other.runtimeType &&
-          languageVersion == other.languageVersion &&
-          update == other.update;
-
-  @override
-  int get hashCode => languageVersion.hashCode ^ update.hashCode;
-
-  @override
-  String toString() {
-    return 'JreVersion{languageVersion: $languageVersion, update: $update}';
-  }
 
   @override
   int compareTo(JreVersion other) {
@@ -53,4 +29,10 @@ class JreVersion extends Comparable<JreVersion> {
 
     return update - other.update;
   }
+
+  @override
+  List<Object?> get props => [languageVersion, update];
+
+  @override
+  bool? get stringify => true;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,6 +162,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   ffi:
     dependency: "direct main"
     description:
@@ -414,13 +421,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  tar:
-    dependency: "direct main"
-    description:
-      name: tar
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   ffi: ^1.1.2
   path: ^1.8.0
   args: ^2.2.0
+  equatable: ^2.0.3
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
Instead of comparing creating hashCodes, overriding the `==`-operator and creating a toString() method by hand, you just need to specify the properties used while extending Equatable or using the EquatableMixin.

This removes massive amounts of boilerplate code and makes your life easier.